### PR TITLE
DTSPO-26674: Add ipconfig_name and privateip_allocation variables

### DIFF
--- a/inputs-optional.tf
+++ b/inputs-optional.tf
@@ -126,4 +126,17 @@ variable "availability_set_name" {
 variable "platform_update_domain_count" {
   description = "The number of platform update domains for the availability set"
   type        = number
-  }
+  default     = 5
+}
+
+variable "ipconfig_name" {
+  type        = string
+  description = "The name of the IPConfig to asssoicate with the NIC."
+  default     = null
+}
+
+variable "privateip_allocation" {
+  type        = string
+  description = "The type of private IP allocation, either Static or Dynamic."
+  default     = "Dynamic"
+}

--- a/vm.tf
+++ b/vm.tf
@@ -44,6 +44,8 @@ module "virtual-machines" {
   vm_admin_ssh_key       = var.vm_admin_ssh_key
   deploy_entra_extension = true
   rbac_config            = local.rbac_config
+  ipconfig_name          = var.ipconfig_name
+  privateip_allocation   = var.privateip_allocation
 
   disable_password_authentication = true
 }


### PR DESCRIPTION
## Summary
This PR adds two new optional variables to allow users to configure IP configuration settings for the virtual machine network interface:

- `ipconfig_name`: The name of the IPConfig to associate with the NIC (defaults to `null`)
- `privateip_allocation`: The type of private IP allocation, either Static or Dynamic (defaults to `"Dynamic"`)

## Changes Made
1. Added `ipconfig_name` variable to `inputs-optional.tf`
2. Added `privateip_allocation` variable to `inputs-optional.tf`
3. Updated `vm.tf` module call to pass these variables to the virtual-machines module

## Testing
These variables are optional with sensible defaults, so existing configurations will continue to work without changes.

## JIRA
DTSPO-26674